### PR TITLE
Fix status checks for inference examples

### DIFF
--- a/06-text-generation-apps/js-githubmodels/app.js
+++ b/06-text-generation-apps/js-githubmodels/app.js
@@ -39,7 +39,7 @@ export async function main() {
 try { 
 
 
-    if (response.status !== "200") {
+    if (response.status !== 200) {
         throw response.body.error;
     }
     console.log(response.body.choices[0].message.content);

--- a/07-building-chat-applications/js-githubmodels/app.js
+++ b/07-building-chat-applications/js-githubmodels/app.js
@@ -31,7 +31,7 @@ export async function main() {
         }
     });
 
-    if (response.status !== "200") {
+    if (response.status !== 200) {
         throw response.body.error;
     }
 

--- a/11-integrating-with-function-calling/js-githubmodels/app.js
+++ b/11-integrating-with-function-calling/js-githubmodels/app.js
@@ -112,7 +112,7 @@ export async function main() {
             model: modelName
         }
     });
-    if (response.status !== "200") {
+    if (response.status !== 200) {
         throw response.body.error;
     }
 
@@ -153,7 +153,7 @@ export async function main() {
                         model: modelName
                     }
                 });
-                if (response.status !== "200") {
+                if (response.status !== 200) {
                     throw response.body.error;
                 }
                 console.log(`Model response = ${response.body.choices[0].message.content}`);


### PR DESCRIPTION
## Summary
- fix incorrect status code comparisons in JavaScript inference examples

## Testing
- `node --check 06-text-generation-apps/js-githubmodels/app.js`
- `node --check 07-building-chat-applications/js-githubmodels/app.js`
- `node --check 11-integrating-with-function-calling/js-githubmodels/app.js`


------
https://chatgpt.com/codex/tasks/task_e_6841a21198048328be88872a1b37738b